### PR TITLE
Bdv dataset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,9 @@ __pycache__/
 build/
 dist/
 *.egg-info/
+
+# Pycharm
+.idea/
+
+*.err
+*.out

--- a/pybdv/__init__.py
+++ b/pybdv/__init__.py
@@ -1,2 +1,3 @@
 from .converter import convert_to_bdv, make_bdv
+from .bdv_datasets import BdvDataset, BdvDatasetWithStitching
 from .__version__ import __version__

--- a/pybdv/bdv_datasets.py
+++ b/pybdv/bdv_datasets.py
@@ -152,7 +152,7 @@ class BdvDataset:
     The full resolution area is padded, if necessary, to avoid sub-pixel locations in the down-sampling layers
     """
 
-    def __init__(self, path, timepoint, setup_id, downscale_mode='interpolate', n_threads=1, verbose=False):
+    def __init__(self, path, timepoint, setup_id, downscale_mode='mean', n_threads=1, verbose=False):
 
         self._path = path
         self._timepoint = timepoint
@@ -212,7 +212,7 @@ class BdvDatasetWithStitching(BdvDataset):
 
         self._halo = halo
 
-        super().__init__(path, timepoint, setup_id, downscale_mode='interpolate', n_threads=n_threads, verbose=verbose)
+        super().__init__(path, timepoint, setup_id, downscale_mode=downscale_mode, n_threads=n_threads, verbose=verbose)
 
     def set_halo(self, halo):
         """

--- a/test/test_bdv_datasets.py
+++ b/test/test_bdv_datasets.py
@@ -6,7 +6,6 @@ from shutil import rmtree
 import numpy as np
 from pybdv import make_bdv, BdvDataset
 from pybdv.util import open_file, get_key, HDF5_EXTENSIONS
-from matplotlib import pyplot as plt
 
 try:
     import z5py

--- a/test/test_bdv_datasets.py
+++ b/test/test_bdv_datasets.py
@@ -1,0 +1,181 @@
+import os
+import unittest
+from abc import ABC
+from shutil import rmtree
+
+import numpy as np
+from pybdv import make_bdv, BdvDataset
+from pybdv.util import open_file, get_key, HDF5_EXTENSIONS
+
+try:
+    import z5py
+except ImportError:
+    z5py = None
+
+
+class UtilTestMixin(ABC):
+    tmp_folder = './tmp'
+    xml_path = './tmp/test.xml'
+    shape = (128,) * 3
+    scale_factors = [[2, 2, 2]] * 3
+    abs_scale_factors = [[1., 1., 1.],
+                         [2., 2., 2.],
+                         [4., 4., 4.],
+                         [8., 8., 8.]]
+
+    def tearDown(self):
+        try:
+            rmtree(self.tmp_folder)
+        except OSError:
+            pass
+
+    def setUp(self):
+        os.makedirs(self.tmp_folder, exist_ok=True)
+        # data = np.random.rand(*self.shape)
+        data = np.zeros(self.shape)
+        make_bdv(data, self.out_path, downscale_factors=self.scale_factors)
+
+    def check_data(self, pos, shp):
+
+        is_h5 = os.path.splitext(self.out_path)[1] in HDF5_EXTENSIONS
+
+        # Make the reference data from scratch
+        ref_data = np.zeros(self.shape)
+        pos = np.array(pos)
+        offset = np.array((0,) * 3)
+        offset[pos < 0] = pos[pos < 0]
+        pos[pos < 0] = 0
+        ref_data[
+            pos[0]: pos[0] + shp[0] + offset[0],
+            pos[1]: pos[1] + shp[1] + offset[1],
+            pos[2]: pos[2] + shp[2] + offset[2]
+        ] = 1
+        if is_h5:
+            ref_out_path = os.path.join(self.tmp_folder, 'ref_tmp_data.h5')
+        else:
+            ref_out_path = os.path.join(self.tmp_folder, 'ref_tmp_data.n5')
+        make_bdv(ref_data, ref_out_path, downscale_factors=self.scale_factors)
+
+        for scale in self.scale_factors:
+            with open_file(self.out_path, mode='r') as f:
+                data = f[get_key(is_h5, timepoint=0, setup_id=0, scale=0)][:]
+            with open_file(ref_out_path, mode='r') as f:
+                ref_data = f[get_key(is_h5, timepoint=0, setup_id=0, scale=0)][:]
+
+            # Now check for the difference
+            self.assertEqual(np.abs(data - ref_data).max(), 0)
+
+    def test_write_data(self):
+
+        pos = (32,) * 3
+        shp = (64,) * 3
+        print(f'pos = {pos}; shp = {shp}')
+
+        vol = np.ones(shp)
+
+        ds = BdvDataset(self.out_path, timepoint=0, setup_id=0, downscale_mode='interpolate')
+        ds[
+            pos[0]: pos[0] + shp[0],
+            pos[1]: pos[1] + shp[1],
+            pos[2]: pos[2] + shp[2]
+        ] = vol
+
+        self.check_data(pos, shp)
+
+    def test_write_out_of_bounds_pos(self):
+
+        pos = (96,) * 3
+        shp = (64,) * 3
+        print(f'pos = {pos}; shp = {shp}')
+
+        vol = np.ones(shp)
+
+        ds = BdvDataset(self.out_path, timepoint=0, setup_id=0, downscale_mode='interpolate')
+        ds[
+            pos[0]: pos[0] + shp[0],
+            pos[1]: pos[1] + shp[1],
+            pos[2]: pos[2] + shp[2]
+        ] = vol
+
+        self.check_data(pos, shp)
+
+    def test_write_out_of_bounds_neg(self):
+
+        pos = (-32,) * 3
+        shp = (64,) * 3
+        print(f'pos = {pos}; shp = {shp}')
+
+        vol = np.ones(shp)
+
+        ds = BdvDataset(self.out_path, timepoint=0, setup_id=0, downscale_mode='interpolate')
+        ds[
+            pos[0]: pos[0] + shp[0],
+            pos[1]: pos[1] + shp[1],
+            pos[2]: pos[2] + shp[2]
+        ] = vol
+
+        self.check_data(pos, shp)
+
+    def test_write_data_subpx(self):
+
+        pos = (35,) * 3
+        shp = (66,) * 3
+        print(f'pos = {pos}; shp = {shp}')
+
+        vol = np.ones(shp)
+
+        ds = BdvDataset(self.out_path, timepoint=0, setup_id=0, downscale_mode='interpolate', verbose=True)
+        ds[
+            pos[0]: pos[0] + shp[0],
+            pos[1]: pos[1] + shp[1],
+            pos[2]: pos[2] + shp[2]
+        ] = vol
+
+        self.check_data(pos, shp)
+
+    def test_write_out_of_bounds_pos_subpx(self):
+
+        pos = (99,) * 3
+        shp = (66,) * 3
+        print(f'pos = {pos}; shp = {shp}')
+
+        vol = np.ones(shp)
+
+        ds = BdvDataset(self.out_path, timepoint=0, setup_id=0, downscale_mode='interpolate')
+        ds[
+            pos[0]: pos[0] + shp[0],
+            pos[1]: pos[1] + shp[1],
+            pos[2]: pos[2] + shp[2]
+        ] = vol
+
+        self.check_data(pos, shp)
+
+    def test_write_out_of_bounds_neg_subpx(self):
+
+        pos = (-35,) * 3
+        shp = (66,) * 3
+        print(f'pos = {pos}; shp = {shp}')
+
+        vol = np.ones(shp)
+
+        ds = BdvDataset(self.out_path, timepoint=0, setup_id=0, downscale_mode='interpolate')
+        ds[
+            pos[0]: pos[0] + shp[0],
+            pos[1]: pos[1] + shp[1],
+            pos[2]: pos[2] + shp[2]
+        ] = vol
+
+        self.check_data(pos, shp)
+
+
+class TestUtilH5(UtilTestMixin, unittest.TestCase):
+    out_path = './tmp/test.h5'
+
+
+@unittest.skipUnless(z5py is not None, "Need z5py for n5 support")
+class TestConvertToBdvN5(UtilTestMixin, unittest.TestCase):
+    out_path = './tmp/test.n5'
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_bdv_datasets.py
+++ b/test/test_bdv_datasets.py
@@ -12,6 +12,8 @@ try:
 except ImportError:
     z5py = None
 
+DOWNSCALE_MODE = 'interpolate'
+
 
 class UtilTestMixin(ABC):
     tmp_folder = './tmp'
@@ -33,7 +35,7 @@ class UtilTestMixin(ABC):
         os.makedirs(self.tmp_folder, exist_ok=True)
         # data = np.random.rand(*self.shape)
         data = np.zeros(self.shape)
-        make_bdv(data, self.out_path, downscale_factors=self.scale_factors)
+        make_bdv(data, self.out_path, downscale_factors=self.scale_factors, downscale_mode=DOWNSCALE_MODE)
 
     def check_data(self, pos, shp):
 
@@ -54,13 +56,13 @@ class UtilTestMixin(ABC):
             ref_out_path = os.path.join(self.tmp_folder, 'ref_tmp_data.h5')
         else:
             ref_out_path = os.path.join(self.tmp_folder, 'ref_tmp_data.n5')
-        make_bdv(ref_data, ref_out_path, downscale_factors=self.scale_factors)
+        make_bdv(ref_data, ref_out_path, downscale_factors=self.scale_factors, downscale_mode=DOWNSCALE_MODE)
 
-        for scale in self.scale_factors:
+        for idx, scale in enumerate(self.abs_scale_factors):
             with open_file(self.out_path, mode='r') as f:
-                data = f[get_key(is_h5, timepoint=0, setup_id=0, scale=0)][:]
+                data = f[get_key(is_h5, timepoint=0, setup_id=0, scale=idx)][:]
             with open_file(ref_out_path, mode='r') as f:
-                ref_data = f[get_key(is_h5, timepoint=0, setup_id=0, scale=0)][:]
+                ref_data = f[get_key(is_h5, timepoint=0, setup_id=0, scale=idx)][:]
 
             # Now check for the difference
             self.assertEqual(np.abs(data - ref_data).max(), 0)
@@ -73,7 +75,7 @@ class UtilTestMixin(ABC):
 
         vol = np.ones(shp)
 
-        ds = BdvDataset(self.out_path, timepoint=0, setup_id=0, downscale_mode='interpolate')
+        ds = BdvDataset(self.out_path, timepoint=0, setup_id=0, downscale_mode=DOWNSCALE_MODE)
         ds[
             pos[0]: pos[0] + shp[0],
             pos[1]: pos[1] + shp[1],
@@ -90,7 +92,7 @@ class UtilTestMixin(ABC):
 
         vol = np.ones(shp)
 
-        ds = BdvDataset(self.out_path, timepoint=0, setup_id=0, downscale_mode='interpolate')
+        ds = BdvDataset(self.out_path, timepoint=0, setup_id=0, downscale_mode=DOWNSCALE_MODE)
         ds[
             pos[0]: pos[0] + shp[0],
             pos[1]: pos[1] + shp[1],
@@ -107,7 +109,7 @@ class UtilTestMixin(ABC):
 
         vol = np.ones(shp)
 
-        ds = BdvDataset(self.out_path, timepoint=0, setup_id=0, downscale_mode='interpolate')
+        ds = BdvDataset(self.out_path, timepoint=0, setup_id=0, downscale_mode=DOWNSCALE_MODE)
         ds[
             pos[0]: pos[0] + shp[0],
             pos[1]: pos[1] + shp[1],
@@ -124,7 +126,7 @@ class UtilTestMixin(ABC):
 
         vol = np.ones(shp)
 
-        ds = BdvDataset(self.out_path, timepoint=0, setup_id=0, downscale_mode='interpolate', verbose=True)
+        ds = BdvDataset(self.out_path, timepoint=0, setup_id=0, downscale_mode=DOWNSCALE_MODE, verbose=True)
         ds[
             pos[0]: pos[0] + shp[0],
             pos[1]: pos[1] + shp[1],
@@ -141,7 +143,7 @@ class UtilTestMixin(ABC):
 
         vol = np.ones(shp)
 
-        ds = BdvDataset(self.out_path, timepoint=0, setup_id=0, downscale_mode='interpolate')
+        ds = BdvDataset(self.out_path, timepoint=0, setup_id=0, downscale_mode=DOWNSCALE_MODE)
         ds[
             pos[0]: pos[0] + shp[0],
             pos[1]: pos[1] + shp[1],
@@ -158,7 +160,7 @@ class UtilTestMixin(ABC):
 
         vol = np.ones(shp)
 
-        ds = BdvDataset(self.out_path, timepoint=0, setup_id=0, downscale_mode='interpolate')
+        ds = BdvDataset(self.out_path, timepoint=0, setup_id=0, downscale_mode=DOWNSCALE_MODE)
         ds[
             pos[0]: pos[0] + shp[0],
             pos[1]: pos[1] + shp[1],

--- a/test/test_bdv_datasets.py
+++ b/test/test_bdv_datasets.py
@@ -6,16 +6,17 @@ from shutil import rmtree
 import numpy as np
 from pybdv import make_bdv, BdvDataset
 from pybdv.util import open_file, get_key, HDF5_EXTENSIONS
+from matplotlib import pyplot as plt
 
 try:
     import z5py
 except ImportError:
     z5py = None
 
-DOWNSCALE_MODE = 'interpolate'
+DOWNSCALE_MODE = 'mean'
 
 
-class UtilTestMixin(ABC):
+class BdvDatasetTestMixin(ABC):
     tmp_folder = './tmp'
     xml_path = './tmp/test.xml'
     shape = (128,) * 3
@@ -170,12 +171,12 @@ class UtilTestMixin(ABC):
         self.check_data(pos, shp)
 
 
-class TestUtilH5(UtilTestMixin, unittest.TestCase):
+class TestBdvDatasetH5(BdvDatasetTestMixin, unittest.TestCase):
     out_path = './tmp/test.h5'
 
 
 @unittest.skipUnless(z5py is not None, "Need z5py for n5 support")
-class TestConvertToBdvN5(UtilTestMixin, unittest.TestCase):
+class TestBdvDatasetN5(BdvDatasetTestMixin, unittest.TestCase):
     out_path = './tmp/test.n5'
 
 


### PR DESCRIPTION
Hi @constantinpape,

I added the BdvDataset as discussed. 
The usage would be:

```
from pybdv.bdv_datasets import BdvDataset
bdv = BdvDataset('/path/to/existing/dataset', timepoint, setup_id)

some_volume = np.ones(shape)
bdv[0: shape[0], 0:shape[1], 0:shape[2]] = some_volume
```

Now some_volume will be properly written into each of the present resolution levels.
If initial padding is required the area from the existing data is loaded, some_volume is put into the array and the padded version is written to the dataset.
If parts of the data would be out of bounds (even a negative start position would work), some_volume is cropped accordingly and the remaining data written to the proper position


Potential issues:
 - I am using the make_bdv function to generate a temporary bdv dataset with the downsampled versions and then load those back in memory to write to the target dataset -> Not necessary, we should directly do the downsamplings in memory
 - For the padding, I load the full data from the target region, so there is some redundant data loading happening


Cheers,
Julian

